### PR TITLE
fix: fix GitHub Actions workflow

### DIFF
--- a/.github/workflows/plugin-build-test.yml
+++ b/.github/workflows/plugin-build-test.yml
@@ -29,9 +29,9 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      # Make gradlew executable
-      - name: Make gradlew executable
-        run: chmod +x ./gradlew && chmod +x *.sh
+      # Make scripts executable
+      - name: Make scripts executable
+        run: chmod +x ./gradlew && chmod +x ./compileDebug && chmod +x ./compileRelease
 
       # Build (Debug)
       - name: Compile Debug


### PR DESCRIPTION
This PR fixes the workflow file because the debug and release scripts no longer have a `.sh` file extension.