### PR TITLE
fix: update regex patterns in schema

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -17,7 +17,7 @@
     },
     "id": {
       "type": "string",
-      "pattern": "^[a-zA-Z][a-zA-Z0-9]*(\\.[a-zA-Z][a-zA-Z0-9]*)+$",
+      "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$",
       "description": "Unique identifier of the extension (package name)"
     },
     "name": {
@@ -27,7 +27,7 @@
     },
     "mainClass": {
       "type": "string",
-      "pattern": "^[a-zA-Z][a-zA-Z0-9]*(\\.[a-zA-Z][a-zA-Z0-9]*)+$",
+      "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+\\.[A-Z][a-zA-Z0-9_]*$",
       "description": "Fully qualified entry class name"
     },
     "version": {

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -33,7 +33,7 @@
     "version": {
       "type": "string",
       "default": "1.0.0",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
       "description": "Semantic version string"
     },
     "description": {


### PR DESCRIPTION
Update `id`, `mainClass` and `version` regex patterns in schema.